### PR TITLE
Custom Unit Visibility Fix

### DIFF
--- a/CSA3/LocalAssetBundle.cs
+++ b/CSA3/LocalAssetBundle.cs
@@ -30,6 +30,8 @@ namespace CheeseMods.CSA3
             MissingComponent = 1 << 9,
             UnsupportedCustomAssetType = 1 << 10,
             InvalidDependancy = 1 << 11,
+            
+            OldDLLVersion =  1 << 13,
         }
 
         public enum Fault
@@ -430,10 +432,9 @@ namespace CheeseMods.CSA3
                 {
                     targetIdentity.index = customUnit.customUnitTargetIndex;
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
-                    Debug.LogError("Old Version of CSA CustomUnit, ask Mod author to update the CSA3Components " +
-                                   "DLL in their unity project. \n Exception: "+e);
+                    ReportErrors(LocalAssetBundleErrors.OldDLLVersion, "Ask the Mod author to update their CSA3Components DLL in their Unity project", Fault.BundleDev);
                     targetIdentity.index = 0;
                 }
             }

--- a/CSA3/LocalAssetBundle.cs
+++ b/CSA3/LocalAssetBundle.cs
@@ -424,6 +424,19 @@ namespace CheeseMods.CSA3
             }
 
             TargetIdentity targetIdentity = TargetIdentityManager.RegisterNonSpawnIdentity(unitID.unitID, unitID.targetName, unitID.role);
+            if (customObject is CSA3_CustomUnit customUnit)
+            {
+                try
+                {
+                    targetIdentity.index = customUnit.customUnitTargetIndex;
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError("Old Version of CSA CustomUnit, ask Mod author to update the CSA3Components " +
+                                   "DLL in their unity project. \n Exception: "+e);
+                    targetIdentity.index = 0;
+                }
+            }
             if (!TargetIdentityManager.indexedIdentities.Contains(targetIdentity))
                 TargetIdentityManager.indexedIdentities.Add(targetIdentity);
         }

--- a/CSA3/Patches/Patch_ReplayPlayback.cs
+++ b/CSA3/Patches/Patch_ReplayPlayback.cs
@@ -28,9 +28,8 @@ public class Patch_ReplayPlayback
                     continue;
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
-                Console.WriteLine(e);
                 continue;
             }
             var gameObject = Object.Instantiate(replayPrefab);

--- a/CSA3/Patches/Patch_ReplayPlayback.cs
+++ b/CSA3/Patches/Patch_ReplayPlayback.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using CheeseMods.CSA3Components;
+using HarmonyLib;
+using ReplaySystem;
+using UnityEngine;
+using VTOLVR.ReplaySystem;
+using Object = UnityEngine.Object;
+
+namespace CheeseMods.CSA3.Patches;
+
+[HarmonyPatch(typeof(ReplayPlayback))]
+public class Patch_ReplayPlayback
+{
+    [HarmonyPatch(nameof(ReplayPlayback.BeginPlayback))]
+    [HarmonyPrefix]
+    private static void BeginPlaybackPrefix(ReplayPlayback __instance)
+    {
+        Debug.Log("Beginning ReplayPlayback.BeginPlayback Prefix Patch");
+        foreach (var customObject in AssetLoader.GetAllCustomObjects(CustomObjectType.CustomUnit))
+        {
+            var unit = customObject as CSA3_CustomUnit;
+            GameObject replayPrefab;
+            try
+            {
+                replayPrefab = unit?.replayModelPrefab;
+                if (replayPrefab == null)
+                {//that means it will be using a plain model and not anything custom
+                    continue;
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                continue;
+            }
+            var gameObject = Object.Instantiate(replayPrefab);
+            gameObject.SetActive(false);
+            
+            var modelOverride = new ReplayPlayback.EntityModelOverride
+            {
+                identities = [unit.customUnitTargetIndex],
+                overridePrefab = gameObject
+            };
+            __instance.modelOverrides.Add(modelOverride);
+        }
+    }
+}

--- a/CSA3/Patches/Patch_ReplayPlaybackUI.cs
+++ b/CSA3/Patches/Patch_ReplayPlaybackUI.cs
@@ -1,0 +1,35 @@
+﻿using HarmonyLib;
+using ReplaySystem;
+using UnityEngine;
+using VTOLVR.ReplaySystem;
+
+namespace CheeseMods.CSA3.Patches;
+
+[HarmonyPatch(typeof(ReplayPlaybackUI))]
+public class Patch_ReplayPlaybackUI
+{
+    [HarmonyPatch(nameof(ReplayPlaybackUI.Playback_OnEntitySpawned))]
+    [HarmonyPrefix]
+    private static bool OnEntitySpawnedPrefix(ReplayPlaybackUI __instance, ReplayRecorder.ReplayEntity entity)
+    {
+        if (!Actor.IsReplayFollowableEntity(entity.entityType, out var teams) ||
+            __instance.followListItems.ContainsKey(entity.id)) return false;
+        var gameObject = Object.Instantiate(__instance.followUnitTemplate, __instance.followUnitView.content);
+        gameObject.SetActive(true);
+        var component = gameObject.GetComponent<RPFollowEntityListItem>();
+        component.interactable.OnInteract.AddListener(delegate
+        {
+            __instance.BeginFollowingEntity(entity);
+        });
+        component.entityLabel.text = entity.metaData.label;
+        component.entityLabel.color = __instance.teamColors[(int)teams];
+        component.entityIdentity.text = entity.metaData.label;
+        var num = ((RectTransform)__instance.followUnitTemplate.transform).rect.height * __instance.followUnitTemplate.transform.localScale.y;
+        gameObject.transform.localPosition = new Vector3(0f, -num * __instance.followableEnts.Count, 0f);
+        __instance.followableEnts.Add(entity);
+        __instance.followListItems.Add(entity.id, gameObject);
+        __instance.followUnitView.content.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, __instance.followableEnts.Count * num);
+        __instance.followUnitView.ClampVertical();
+        return false;
+    }
+}

--- a/CSA3/Patches/Patch_ReplayPlaybackUI.cs
+++ b/CSA3/Patches/Patch_ReplayPlaybackUI.cs
@@ -23,7 +23,8 @@ public class Patch_ReplayPlaybackUI
         });
         component.entityLabel.text = entity.metaData.label;
         component.entityLabel.color = __instance.teamColors[(int)teams];
-        component.entityIdentity.text = entity.metaData.label;
+        var entityIdentity = TargetIdentityManager.GetIdentity(entity.metaData.identity);
+        component.entityIdentity.text = entityIdentity != null ? entityIdentity.targetName : entity.metaData.label;
         var num = ((RectTransform)__instance.followUnitTemplate.transform).rect.height * __instance.followUnitTemplate.transform.localScale.y;
         gameObject.transform.localPosition = new Vector3(0f, -num * __instance.followableEnts.Count, 0f);
         __instance.followableEnts.Add(entity);

--- a/CSA3/Patches/Patch_TargetIdentityManager.cs
+++ b/CSA3/Patches/Patch_TargetIdentityManager.cs
@@ -1,0 +1,20 @@
+﻿using HarmonyLib;
+
+namespace CheeseMods.CSA3.Patches;
+
+[HarmonyPatch(typeof(TargetIdentityManager))]
+public class Patch_TargetIdentityManager
+{
+    [HarmonyPatch(nameof(TargetIdentityManager.GetIdentity))]
+    [HarmonyPatch([typeof(int)])]
+    [HarmonyPrefix]
+    private static bool GetIdentityPrefix(int identityIndex, ref TargetIdentity __result)
+    {
+        if (identityIndex >= 0 && identityIndex < TargetIdentityManager.indexedIdentities.Count)
+        {
+            __result = TargetIdentityManager.indexedIdentities.Find(x => x.index == identityIndex) ??
+                       TargetIdentityManager.indexedIdentities[0];
+        }
+        return false;
+    }
+}

--- a/CSA3Components/CSA3_CustomObject.cs
+++ b/CSA3Components/CSA3_CustomObject.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace CheeseMods.CSA3Components
 {
@@ -9,12 +7,12 @@ namespace CheeseMods.CSA3Components
         [Tooltip("Autopopulated, don't worry about it")]
         public CSA3_ObjectBundle parentBundle;
 
-        [Tooltip("Disaply name of your asset")]
+        [Tooltip("Display name of your asset")]
         public string displayName;
-        [Tooltip("id for uniquely identifying your asset. " + CSA3_BundleMetadata.namingRules)]
+        [Tooltip("Dd for uniquely identifying your asset. " + CSA3_BundleMetadata.namingRules)]
         public string objectId;
         [TextArea]
-        [Tooltip("Discription of your asset")]
+        [Tooltip("Description of your asset")]
         public string description;
     }
 }

--- a/CSA3Components/CSA3_CustomUnit.cs
+++ b/CSA3Components/CSA3_CustomUnit.cs
@@ -1,6 +1,12 @@
-﻿namespace CheeseMods.CSA3Components
+﻿using UnityEngine;
+
+namespace CheeseMods.CSA3Components
 {
     public class CSA3_CustomUnit : CSA3_CustomObject
     {
+        [Tooltip("Index value to use for a custom model in mission replays")]
+        public int customUnitTargetIndex;
+        [Tooltip("Custom replay Model Prefab (Optional)")]
+        public GameObject replayModelPrefab;
     }
 }

--- a/CSA3Components/CSA3_VersionInfo.cs
+++ b/CSA3Components/CSA3_VersionInfo.cs
@@ -20,8 +20,8 @@
         }
 
         public static int Major => 3;
-        public static int Minor => 0;
-        public static int Patch => 8;
+        public static int Minor => 1;
+        public static int Patch => 0;
 
         public static VersionNumber CurrentVersion => new VersionNumber(Major, Minor, Patch);
     }

--- a/Editor/CSA3_ObjectBundleEditor.cs
+++ b/Editor/CSA3_ObjectBundleEditor.cs
@@ -7,7 +7,7 @@ using UnityEditor;
 using UnityEngine;
 
 [CustomEditor(typeof(CSA3_ObjectBundle))]
-class CSA3_ObjectBundleEditor : Editor
+class CSA3_ObjectBundleEditor : UnityEditor.Editor
 {
     public override void OnInspectorGUI()
     {


### PR DESCRIPTION
This fixes the issue where custom CSA units were not being displayed on mission replays. 
It does this by allowing the unit creators to set their own TargetIdentity.index value.
By pure chance this also fixes the issue where units were getting incorrect names or were called Error on the TSD and such.

This adds the ability to use a custom model for a unit in mission replays.

(I also fixed some spelling mistakes that were bugging me, and fixed the editor script)